### PR TITLE
Adds aws ami owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 ## Usage
 
+
+**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases.
+Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-ec2-instance-group/releases).
+
+
 Note: add `${var.ssh_key_pair}` private key to the `ssh agent`.
 
 Include this repository as a module in your existing terraform code.
@@ -141,7 +146,7 @@ Available targets:
 | additional_ips_count | Count of additional EIPs | string | `0` | no |
 | allowed_ports | List of allowed ingress ports | list | `<list>` | no |
 | ami | The AMI to use for the instance. | string | - | yes |
-| ami_owner | The owner of the given AMI. | string | - | yes |
+| ami_owner | Owner of the given AMI | string | - | yes |
 | applying_period | The period in seconds over which the specified statistic is applied | string | `60` | no |
 | assign_eip_address | Assign an Elastic IP address to the instance | string | `true` | no |
 | associate_public_ip_address | Associate a public IP address with the instance | string | `true` | no |

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ module "instance" {
   stage                       = "prod"
   name                        = "app"
   ami                         = "ami-a4dc46db"
+  ami_owner                   = "099720109477"
   ssh_key_pair                = "${var.ssh_key_pair}"
   instance_type               = "${var.instance_type}"
   vpc_id                      = "${var.vpc_id}"
@@ -86,6 +87,7 @@ module "kafka_instance" {
   stage                       = "prod"
   name                        = "app"
   ami                         = "ami-a4dc46db"
+  ami_owner                   = "099720109477"
   ssh_key_pair                = "${var.ssh_key_pair}"
   vpc_id                      = "${var.vpc_id}"
   security_groups             = ["${var.security_groups}"]
@@ -139,6 +141,7 @@ Available targets:
 | additional_ips_count | Count of additional EIPs | string | `0` | no |
 | allowed_ports | List of allowed ingress ports | list | `<list>` | no |
 | ami | The AMI to use for the instance. | string | - | yes |
+| ami_owner | The owner of the given AMI. | string | - | yes |
 | applying_period | The period in seconds over which the specified statistic is applied | string | `60` | no |
 | assign_eip_address | Assign an Elastic IP address to the instance | string | `true` | no |
 | associate_public_ip_address | Associate a public IP address with the instance | string | `true` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -70,6 +70,7 @@ usage: |-
     stage                       = "prod"
     name                        = "app"
     ami                         = "ami-a4dc46db"
+    ami_owner                   = "099720109477"
     ssh_key_pair                = "${var.ssh_key_pair}"
     instance_type               = "${var.instance_type}"
     vpc_id                      = "${var.vpc_id}"
@@ -89,6 +90,7 @@ usage: |-
     stage                       = "prod"
     name                        = "app"
     ami                         = "ami-a4dc46db"
+    ami_owner                   = "099720109477"
     ssh_key_pair                = "${var.ssh_key_pair}"
     vpc_id                      = "${var.vpc_id}"
     security_groups             = ["${var.security_groups}"]

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,6 +5,7 @@
 | additional_ips_count | Count of additional EIPs | string | `0` | no |
 | allowed_ports | List of allowed ingress ports | list | `<list>` | no |
 | ami | The AMI to use for the instance. | string | - | yes |
+| ami_owner | Owner of the given AMI | string | - | yes |
 | applying_period | The period in seconds over which the specified statistic is applied | string | `60` | no |
 | assign_eip_address | Assign an Elastic IP address to the instance | string | `true` | no |
 | associate_public_ip_address | Associate a public IP address with the instance | string | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -36,18 +36,20 @@ data "aws_ami" "info" {
     name   = "image-id"
     values = ["${var.ami}"]
   }
+
+  owners = ["${var.ami_owner}"]
 }
 
 # Apply the terraform-terraform-label module for this resource
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.1.2"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"
   attributes = "${var.attributes}"
   delimiter  = "${var.delimiter}"
   tags       = "${merge(map("AZ", "${local.availability_zone}"), var.tags)}"
-  enabled    = "true"
+  enabled    = "rue"
 }
 
 resource "aws_iam_instance_profile" "default" {

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ module "label" {
   attributes = "${var.attributes}"
   delimiter  = "${var.delimiter}"
   tags       = "${merge(map("AZ", "${local.availability_zone}"), var.tags)}"
-  enabled    = "rue"
+  enabled    = "true"
 }
 
 resource "aws_iam_instance_profile" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -95,6 +95,10 @@ variable "ami" {
   description = "The AMI to use for the instance."
 }
 
+variable "ami_owner" {
+  description = "Owner of the given AMI"
+}
+
 variable "ebs_optimized" {
   description = "Launched EC2 instance will be EBS-optimized"
   default     = "false"


### PR DESCRIPTION
Fix for #6 

Also bumps the version for terraform-terraform-label as the existing version generated an invalid label for the ami profile.