### PR TITLE
fix: logic of additional EBS count

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -160,16 +160,8 @@ resource "aws_ebs_volume" "default" {
 }
 
 resource "aws_volume_attachment" "default" {
-  count = signum(local.instance_count) == 1 ? var.ebs_volume_count * local.instance_count : 0
-
-  device_name = slice(
-    var.ebs_device_names,
-    0,
-    floor(
-      var.ebs_volume_count * local.instance_count / max(local.instance_count, 1),
-    ),
-  )[count.index]
-
+  count       = signum(local.instance_count) == 1 ? var.ebs_volume_count * local.instance_count : 0
+  device_name = element(slice(var.ebs_device_names, 0, floor(var.ebs_volume_count * local.instance_count / max(local.instance_count, 1))), count.index)
   volume_id   = aws_ebs_volume.default.*.id[count.index]
   instance_id = aws_instance.default.*.id[count.index]
 }


### PR DESCRIPTION

```sh
Error: Invalid index

  on terraform-aws-ec2-instance-group/main.tf line 171, in resource "aws_volume_attachment" "default":
 171:   )[count.index]
    |----------------
    | count.index is 2
    | local.instance_count is 8
    | var.ebs_device_names is list of string with 25 elements
    | var.ebs_volume_count is 1

The given key does not identify an element in this collection value.
```