### PR TITLE
Raised version of module for ssh_key_pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -254,6 +255,7 @@ Available targets:
 | security\_group\_ids | ID on the new AWS Security Group associated with creating instance |
 | ssh\_key\_pem\_path | Path where SSH key pair was created (if applicable) |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -93,3 +94,4 @@
 | security\_group\_ids | ID on the new AWS Security Group associated with creating instance |
 | ssh\_key\_pem\_path | Path where SSH key pair was created (if applicable) |
 
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,7 @@ resource "aws_instance" "default" {
 ##
 
 module "ssh_key_pair" {
-  source                = "git::https://github.com/cloudposse/terraform-aws-key-pair.git?ref=tags/0.9.0"
+  source                = "git::https://github.com/cloudposse/terraform-aws-key-pair.git?ref=tags/0.14.0"
   namespace             = var.namespace
   environment           = var.environment
   stage                 = var.stage


### PR DESCRIPTION
The ssh_key_pair module is pointing to version 0.9.0. However 0.9.0 can only be used with Terraform version 0.12. Result is that this module is broken in 0.12.x+ versions, as you can see in the error that i used with a terraform version 0.13.x:
```
Error: Unsupported Terraform Core version

  on .terraform/modules/instance.ssh_key_pair/versions.tf line 2, in terraform:
   2:   required_version = "~> 0.12.0"
```

In later versions of the ssh_key_pair module this is fixed by this commit: https://github.com/cloudposse/terraform-aws-key-pair/commit/fec52dc96d0f5f59052b8b377df7f72c5b526e42, so i raised this version right up to the latest available.
