### PR TITLE
BridgeCrew compliance checks fixed, README updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.iml
 **/terraform.tfstate
 **/terraform.tfstate.backup
+**/.terraform.lock.hcl
+
 **/*.pem
 **/*.pub
 

--- a/README.md
+++ b/README.md
@@ -179,8 +179,6 @@ Available targets:
 |------|---------|
 | terraform | >= 0.12.26 |
 | aws | >= 2.0 |
-| null | >= 2.0 |
-| tls | >= 2.0 |
 
 ## Providers
 
@@ -199,7 +197,7 @@ Available targets:
 | ami\_owner | Owner of the given AMI | `string` | n/a | yes |
 | applying\_period | The period in seconds over which the specified statistic is applied | `number` | `60` | no |
 | assign\_eip\_address | Assign an Elastic IP address to the instance | `bool` | `true` | no |
-| associate\_public\_ip\_address | Associate a public IP address with the instance | `bool` | `true` | no |
+| associate\_public\_ip\_address | Associate a public IP address with the instance | `bool` | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | availability\_zone | Availability Zone the instance is launched in. If not set, will be launched in the first AZ of the region | `string` | `""` | no |
 | comparison\_operator | The arithmetic operation to use when comparing the specified Statistic and Threshold. Possible values are: GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanThreshold, LessThanOrEqualToThreshold | `string` | `"GreaterThanOrEqualToThreshold"` | no |
@@ -213,6 +211,7 @@ Available targets:
 | ebs\_iops | Amount of provisioned IOPS. This must be set with a volume\_type of io1 | `number` | `0` | no |
 | ebs\_optimized | Launched EC2 instance will be EBS-optimized | `bool` | `false` | no |
 | ebs\_volume\_count | Count of EBS volumes that will be attached to the instance | `number` | `0` | no |
+| ebs\_volume\_encrypted | Size of the EBS volume in gigabytes | `bool` | `true` | no |
 | ebs\_volume\_size | Size of the EBS volume in gigabytes | `number` | `10` | no |
 | ebs\_volume\_type | The type of EBS volume. Can be standard, gp2 or io1 | `string` | `"gp2"` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
@@ -225,7 +224,10 @@ Available targets:
 | instance\_type | The type of the instance | `string` | `"t2.micro"` | no |
 | ipv6\_address\_count | Number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet | `number` | `0` | no |
 | ipv6\_addresses | List of IPv6 addresses from the range of the subnet to associate with the primary network interface | `list(string)` | `[]` | no |
+| kms\_key\_id | KMS key ID used to encrypt EBS volume. When specifying kms\_key\_id, ebs\_volume\_encrypted needs to be set to true | `string` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| metadata\_http\_endpoint\_enabled | Whether the metadata service is available | `bool` | `true` | no |
+| metadata\_http\_tokens\_required | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2. | `bool` | `true` | no |
 | metric\_name | The name for the alarm's associated metric. Allowed values can be found in https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ec2-metricscollected.html | `string` | `"StatusCheckFailed_Instance"` | no |
 | metric\_namespace | The namespace for the alarm's associated metric. Allowed values can be found in https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-namespaces.html | `string` | `"AWS/EC2"` | no |
 | metric\_threshold | The value against which the specified statistic is compared | `number` | `1` | no |
@@ -236,6 +238,7 @@ Available targets:
 | private\_ips | Private IP address to associate with the instances in the VPC | `list(string)` | `[]` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | region | AWS Region the instance is launched in | `string` | n/a | yes |
+| root\_block\_device\_encrypted | Whether to encrypt the root block device | `bool` | `true` | no |
 | root\_iops | Amount of provisioned IOPS. This must be set if root\_volume\_type is set to `io1` | `number` | `0` | no |
 | root\_volume\_size | Size of the root volume in gigabytes | `number` | `10` | no |
 | root\_volume\_type | Type of root volume. Can be standard, gp2 or io1 | `string` | `"gp2"` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,8 +5,6 @@
 |------|---------|
 | terraform | >= 0.12.26 |
 | aws | >= 2.0 |
-| null | >= 2.0 |
-| tls | >= 2.0 |
 
 ## Providers
 
@@ -25,7 +23,7 @@
 | ami\_owner | Owner of the given AMI | `string` | n/a | yes |
 | applying\_period | The period in seconds over which the specified statistic is applied | `number` | `60` | no |
 | assign\_eip\_address | Assign an Elastic IP address to the instance | `bool` | `true` | no |
-| associate\_public\_ip\_address | Associate a public IP address with the instance | `bool` | `true` | no |
+| associate\_public\_ip\_address | Associate a public IP address with the instance | `bool` | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | availability\_zone | Availability Zone the instance is launched in. If not set, will be launched in the first AZ of the region | `string` | `""` | no |
 | comparison\_operator | The arithmetic operation to use when comparing the specified Statistic and Threshold. Possible values are: GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanThreshold, LessThanOrEqualToThreshold | `string` | `"GreaterThanOrEqualToThreshold"` | no |
@@ -39,6 +37,7 @@
 | ebs\_iops | Amount of provisioned IOPS. This must be set with a volume\_type of io1 | `number` | `0` | no |
 | ebs\_optimized | Launched EC2 instance will be EBS-optimized | `bool` | `false` | no |
 | ebs\_volume\_count | Count of EBS volumes that will be attached to the instance | `number` | `0` | no |
+| ebs\_volume\_encrypted | Size of the EBS volume in gigabytes | `bool` | `true` | no |
 | ebs\_volume\_size | Size of the EBS volume in gigabytes | `number` | `10` | no |
 | ebs\_volume\_type | The type of EBS volume. Can be standard, gp2 or io1 | `string` | `"gp2"` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
@@ -51,7 +50,10 @@
 | instance\_type | The type of the instance | `string` | `"t2.micro"` | no |
 | ipv6\_address\_count | Number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet | `number` | `0` | no |
 | ipv6\_addresses | List of IPv6 addresses from the range of the subnet to associate with the primary network interface | `list(string)` | `[]` | no |
+| kms\_key\_id | KMS key ID used to encrypt EBS volume. When specifying kms\_key\_id, ebs\_volume\_encrypted needs to be set to true | `string` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| metadata\_http\_endpoint\_enabled | Whether the metadata service is available | `bool` | `true` | no |
+| metadata\_http\_tokens\_required | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2. | `bool` | `true` | no |
 | metric\_name | The name for the alarm's associated metric. Allowed values can be found in https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ec2-metricscollected.html | `string` | `"StatusCheckFailed_Instance"` | no |
 | metric\_namespace | The namespace for the alarm's associated metric. Allowed values can be found in https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-namespaces.html | `string` | `"AWS/EC2"` | no |
 | metric\_threshold | The value against which the specified statistic is compared | `number` | `1` | no |
@@ -62,6 +64,7 @@
 | private\_ips | Private IP address to associate with the instances in the VPC | `list(string)` | `[]` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | region | AWS Region the instance is launched in | `string` | n/a | yes |
+| root\_block\_device\_encrypted | Whether to encrypt the root block device | `bool` | `true` | no |
 | root\_iops | Amount of provisioned IOPS. This must be set if root\_volume\_type is set to `io1` | `number` | `0` | no |
 | root\_volume\_size | Size of the root volume in gigabytes | `number` | `10` | no |
 | root\_volume\_type | Type of root volume. Can be standard, gp2 or io1 | `string` | `"gp2"` | no |

--- a/main.tf
+++ b/main.tf
@@ -81,7 +81,7 @@ resource "aws_iam_role" "default" {
 }
 
 resource "aws_instance" "default" {
-  #bridgecrew:skip=BC_AWS_GENERAL_31: Skipping `Ensure Instance Metadata Service Version 1 is not enabled` check until BridgeCrew support condition evaluation. See https://github.com/bridgecrewio/checkov/issues/793
+  #bridgecrew:skip=BC_AWS_GENERAL_31: Skipping `Ensure Instance Metadata Service Version 1 is not enabled` check until BridgeCrew supports conditional evaluation. See https://github.com/bridgecrewio/checkov/issues/793
   count                       = local.instance_count
   ami                         = data.aws_ami.info.id
   availability_zone           = local.availability_zone

--- a/main.tf
+++ b/main.tf
@@ -77,9 +77,11 @@ resource "aws_iam_role" "default" {
   path                 = "/"
   assume_role_policy   = data.aws_iam_policy_document.default.json
   permissions_boundary = length(var.permissions_boundary_arn) > 0 ? var.permissions_boundary_arn : null
+  tags                 = module.this.tags
 }
 
 resource "aws_instance" "default" {
+  #bridgecrew:skip=BC_AWS_GENERAL_31: Skipping `Ensure Instance Metadata Service Version 1 is not enabled` check until BridgeCrew support condition evaluation. See https://github.com/bridgecrewio/checkov/issues/793
   count                       = local.instance_count
   ami                         = data.aws_ami.info.id
   availability_zone           = local.availability_zone
@@ -111,6 +113,13 @@ resource "aws_instance" "default" {
     volume_size           = var.root_volume_size
     iops                  = local.root_iops
     delete_on_termination = var.delete_on_termination
+    encrypted             = var.root_block_device_encrypted
+    kms_key_id            = var.kms_key_id
+  }
+
+  metadata_options {
+    http_endpoint = var.metadata_http_endpoint_enabled ? "enabled" : "disabled"
+    http_tokens   = var.metadata_http_tokens_required ? "required" : "optional"
   }
 
   tags = merge(
@@ -149,6 +158,8 @@ resource "aws_ebs_volume" "default" {
   iops              = local.ebs_iops
   type              = var.ebs_volume_type
   tags              = module.label.tags
+  encrypted         = var.ebs_volume_encrypted
+  kms_key_id        = var.kms_key_id
 }
 
 resource "aws_volume_attachment" "default" {

--- a/main.tf
+++ b/main.tf
@@ -149,6 +149,7 @@ resource "aws_eip" "default" {
   network_interface = aws_instance.default.*.primary_network_interface_id[count.index]
   vpc               = true
   depends_on        = [aws_instance.default]
+  tags              = module.this.tags
 }
 
 resource "aws_ebs_volume" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,7 @@ variable "generate_ssh_key_pair" {
 variable "associate_public_ip_address" {
   type        = bool
   description = "Associate a public IP address with the instance"
-  default     = true
+  default     = false
 }
 
 variable "ssh_key_pair_path" {
@@ -261,4 +261,34 @@ variable "permissions_boundary_arn" {
   type        = string
   description = "Policy ARN to attach to instance role as a permissions boundary"
   default     = ""
+}
+
+variable "root_block_device_encrypted" {
+  type        = bool
+  default     = true
+  description = "Whether to encrypt the root block device"
+}
+
+variable "metadata_http_tokens_required" {
+  type        = bool
+  default     = true
+  description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2."
+}
+
+variable "metadata_http_endpoint_enabled" {
+  type        = bool
+  default     = true
+  description = "Whether the metadata service is available"
+}
+
+variable "kms_key_id" {
+  type        = string
+  default     = null
+  description = "KMS key ID used to encrypt EBS volume. When specifying kms_key_id, ebs_volume_encrypted needs to be set to true"
+}
+
+variable "ebs_volume_encrypted" {
+  type        = bool
+  description = "Size of the EBS volume in gigabytes"
+  default     = true
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,13 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.0"
     }
-    tls = {
-      source  = "hashicorp/tls"
-      version = ">= 2.0"
-    }
-    null = {
-      source  = "hashicorp/null"
-      version = ">= 2.0"
-    }
   }
 }


### PR DESCRIPTION
## what
* BridgeCrew compliance checks fix
* readme updated
* default behaviour changed: Public IP for EC2 instance disabled by default
* default behaviour changed: `Instance Metadata Service Version 2` forced by default
* default behaviour changed: `Encryption of the root block device` enabled by default
* default behaviour changed: `Encrypt EBS Volume` enabled by default

## why
* To be able to position our modules as standards compliant
* stay in sync with code
* To comply BridgeCrew check

## references
* https://docs.bridgecrew.io/docs/public_12
* https://docs.bridgecrew.io/docs/general_13
* https://docs.bridgecrew.io/docs/bc_aws_general_31
* https://docs.bridgecrew.io/docs/general_3-encrypt-eps-volume